### PR TITLE
Add tooltips to buttons in MainWindow and update UI layout

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -71,7 +71,7 @@
 #include <QComboBox>
 #include <QScrollBar>
 #include <QGuiApplication>
-
+#include <QToolTip>
 
 Q_LOGGING_CATEGORY(log_ui_mainwindow, "opf.ui.mainwindow")
 
@@ -281,6 +281,16 @@ MainWindow::MainWindow() :  ui(new Ui::MainWindow),
 
     ScriptTool *scriptTool = new ScriptTool(this);
     connect(scriptTool, &ScriptTool::syntaxTreeReady, this, &MainWindow::handleSyntaxTree);
+    setTooltip();
+}
+
+void MainWindow::setTooltip(){
+    ui->ZoomInButton->setToolTip("zoom in");
+    ui->ZoomOutButton->setToolTip("zoom out");
+    ui->ZoomReductionButton->setToolTip("restore original size");
+    ui->virtualKeyboardButton->setToolTip("special & combine key");
+    ui->pasteButton->setToolTip("paste text to target");
+    ui->screensaverButton->setToolTip("mouse dance");
 }
 
 void MainWindow::onZoomIn()

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -121,7 +121,7 @@ private slots:
     void officialLink();
     void aboutLink();
     void updateLink();
-    
+    void setTooltip();
 
     void configureSettings();
     void debugSerialPort();

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -120,7 +120,7 @@
        </property>
       </widget>
      </item>
-     <item>
+     <!-- <item>
       <widget class="QPushButton" name="contrastButton">
        <property name="icon">
         <iconset resource="mainwindow.qrc">
@@ -130,7 +130,7 @@
         <bool>true</bool>
        </property>
       </widget>
-     </item>
+     </item> -->
     </layout>
    </widget>
    <widget class="QMenu" name="menuFile">


### PR DESCRIPTION
- Introduced tooltips for Zoom In, Zoom Out, Zoom Reduction, Virtual Keyboard, Paste, and Screensaver buttons to enhance user experience.
- Updated mainwindow.h to declare the new setTooltip method.
- Commented out an unused item in mainwindow.ui for cleaner UI structure.

These changes improve accessibility and usability of the MainWindow interface.